### PR TITLE
Remove unnecessary headers in API request

### DIFF
--- a/api/endpoints/real_estate.py
+++ b/api/endpoints/real_estate.py
@@ -57,7 +57,7 @@ async def get_openai_response(life_situation: str, monthly_income_range: str):
 
     return json.loads(completion.choices[0].message.content)
 
-@router.get("/real_estate_recommendation/")
+@router.post("/real_estate_recommendation/")
 async def get_real_estate_by_location_price_size(filter: RealEstateFilter):
     openai_response = await get_openai_response(filter.life_situation, filter.monthly_income_range)
     print(openai_response)

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -32,7 +32,7 @@ const Home: NextPage = () => {
     setLoading(true);
   
     const response = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/api/real_estate_recommendation`, {
-      method: 'GET',
+      method: 'POST',
       body: JSON.stringify({
         "life_situation": lifeSituation,
         "monthly_income_range": income


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Simplified the API request in `pages/index.tsx` by removing the 'Content-Type' header, which was unnecessary for a GET request.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Simplify API Request by Removing Unnecessary Headers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pages/index.tsx
- Removed unnecessary 'Content-Type' header from the API request.



</details>
    

  </td>
  <td><a href="https://github.com/karlosmatos/home-ai-advisor/pull/3/files#diff-aa98fd0757d0e1741503c50cfafb7726939d19819638bbe8e030a27adfec34a3">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

